### PR TITLE
Add docs and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Guidelines for GPT Codex
+
+This repository contains **KoraLibC**, a minimal C standard library for KoraOS.
+All contributions should follow these principles:
+
+- **Language**: C99. Avoid compiler extensions and keep the code freestanding.
+- **Style**: Use spaces for indentation (no tabs) and match the formatting of the
+  existing source files.
+- **Build**: Use CMake. Typical steps are `mkdir build && cd build && cmake .. && make`.
+- **Testing**: If CMocka is installed, run `ctest` from the `build/` directory
+  after building.
+- **Scope**: The library depends on the syscalls defined in the
+  [KoraLayer](https://github.com/lazerlabs/koralayer) project. When features rely
+  on missing syscalls, provide stub implementations with TODO comments.
+- **Documentation**: Keep `docs/README.md` and `docs/PRD.md` up to date when
+  relevant changes occur.
+

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,50 @@
+# KoraLibC Product Requirements Document
+
+This document outlines the remaining tasks to complete the KoraLibC
+implementation. It serves as a guide for future work and provides context for
+any contributor using GPT Codex.
+
+## Background
+
+KoraLibC is a minimal C standard library tailored for KoraOS. It relies on the
+syscall ABI exposed by the [KoraLayer](https://github.com/lazerlabs/koralayer)
+project. The library is currently functional for basic string handling, ctype,
+stdlib utilities and a partial stdio implementation.
+
+## Goals
+
+1. Provide a freestanding libc for KoraOS that offers a familiar set of C99
+   APIs.
+2. Keep the implementation small and easy to audit.
+3. Remain compatible with the KoraLayer syscall interface.
+4. Include unit tests wherever possible.
+
+## Phase 2 Roadmap
+
+The following features are planned next:
+
+1. **Memory Management** – implement `malloc`, `free`, `realloc` and friends
+   using KoraLayer syscalls.
+2. **File I/O** – support for `fopen`, `fread`, `fwrite`, etc.
+3. **Process Control** – implement `exit` and process management calls.
+4. **Environment Management** – functions like `getenv`, `setenv`, `unsetenv`.
+5. **Math Library** – add `math.h` with common math functions.
+6. **Time Functions** – provide `time.h` functionality (clocks, timestamps).
+
+These areas depend on the underlying kernel facilities and will evolve as the
+KoraLayer API stabilises.
+
+## Development Guidelines
+
+- Follow the coding style used in the existing source files (spaces for
+  indentation, ANSI C99).
+- Keep functions simple and well commented.
+- Where functionality depends on yet-to-be-defined syscalls, provide stubs with
+  clear TODO comments.
+- Extend unit tests in `tests/` as new modules are added.
+
+## References
+
+More information on the guiding principles can be found in the chat thread:
+<https://chatgpt.com/g/g-p-677ac79d60d48191b1c0684b10248485-kora/c/67b38599-d1cc-800a-91d3-bb6e12a295e3>
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,90 @@
+# KoraLibC Documentation
+
+KoraLibC is a freestanding implementation of the C standard library for **KoraOS**. The
+project provides a minimal subset of libc written in C99 and relies on the
+syscall interface defined in [KoraLayer](https://github.com/lazerlabs/koralayer).
+
+This document describes the repository layout, how to build the library, and the
+interfaces currently available.
+
+## Repository layout
+
+```
+include/       Public headers
+src/           Library implementation
+tests/         Unit tests (optional, requires CMocka)
+docs/          Project documentation
+```
+
+The root `README.md` provides an overview of the implemented features and design
+philosophy. This `docs/README.md` focuses on how to work with the codebase.
+
+## Building
+
+KoraLibC uses CMake. A standard build looks like this:
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+If [CMocka](https://cmocka.org/) is available, the tests will be compiled and can
+be executed with `ctest`:
+
+```bash
+ctest
+```
+
+The build produces both static (`libkoralibc.a`) and shared (`libkoralibc.so`)
+libraries in the `build/` directory.
+
+## Headers and API
+
+The library exposes a subset of the standard C headers under `include/`:
+
+- `stddef.h` – C99 definitions like `size_t` and `NULL`.
+- `stdint.h` – fixed width integer types.
+- `stdbool.h` – the `bool` type and constants.
+- `stdarg.h` – variable argument handling.
+- `limits.h` – fundamental limits.
+- `errno.h` – error codes.
+- `assert.h` – runtime assertions.
+- `kora/sys/types.h` – platform specific typedefs used throughout KoraOS.
+- `kora/string.h` – basic string and memory helpers.
+- `kora/ctype.h` – character classification helpers.
+- `kora/stdlib.h` – minimal standard library functions.
+- `kora/stdio.h` – partial stdio implementation.
+
+These headers implement familiar C interfaces. Many functions are still
+incomplete or stubbed out while the syscall layer is being finalised. See the
+source files in `src/` for details.
+
+## Example
+
+A minimal program using KoraLibC might look like:
+
+```c
+#include <kora/string.h>
+#include <kora/stdio.h>
+
+int main(void) {
+    char msg[] = "Hello from KoraLibC";
+    kora_printf("%s\n", msg);
+    return 0;
+}
+```
+
+Compile it with:
+
+```bash
+gcc -o hello hello.c -Iinclude build/libkoralibc.a
+```
+
+## Further reading
+
+For a more detailed discussion of architecture decisions, see `README.md` in the
+repository root. The [Product Requirements Document](PRD.md) outlines the plan
+for completing the rest of the library.
+


### PR DESCRIPTION
## Summary
- document build and API usage in `docs/README.md`
- add `docs/PRD.md` describing remaining libc work
- introduce `AGENTS.md` with contribution guidelines

## Testing
- `cmake ..`
- `make`
- `ctest --output-on-failure`
